### PR TITLE
Keep drive perf results order as passed arguments

### DIFF
--- a/pkg/dperf/perf.go
+++ b/pkg/dperf/perf.go
@@ -100,10 +100,6 @@ func (d *DrivePerf) Run(ctx context.Context, paths ...string) ([]*DrivePerfResul
 		os.RemoveAll(res.Path)
 	}
 
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].ReadThroughput > results[j].ReadThroughput
-	})
-
 	return results, nil
 }
 
@@ -113,6 +109,11 @@ func (d *DrivePerf) RunAndRender(ctx context.Context, paths ...string) error {
 	if err != nil {
 		return err
 	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].ReadThroughput > results[j].ReadThroughput
+	})
+
 	d.render(results)
 	return nil
 }


### PR DESCRIPTION
Do not order drive performance results in Run(). The order should be the
same as the drive paths passed as arguments.