### PR TITLE
Make IOPerDrive Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Examples:
 Flags:
   -b, --blocksize string   read/write block size (default "4MiB")
   -f, --filesize string    amount of data to read/write per drive (default "1GiB")
+  -i, --ioperdrive int     number of concurrent I/O per drive (default 4)
   -h, --help               help for dperf
       --serial             run tests one by one, instead of all at once.
       --version            version for dperf

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -42,11 +42,12 @@ const alignSize = 4096
 
 // flags
 var (
-	serial    = false
-	verbose   = false
-	blockSize = "4MiB"
-	fileSize  = "1GiB"
-	cpuNode   = 0
+	serial     = false
+	verbose    = false
+	blockSize  = "4MiB"
+	fileSize   = "1GiB"
+	cpuNode    = 0
+	ioPerDrive = 4
 )
 
 var dperfCmd = &cobra.Command{
@@ -123,11 +124,16 @@ $ dperf --serial /mnt/drive{1..6}
 			return fmt.Errorf("Invalid filesize must multiples of 4k: %d", fs)
 		}
 
+		if ioPerDrive <= 0 {
+			return fmt.Errorf("Invalid ioperdrive must greater than 0: %d", ioPerDrive)
+		}
+
 		perf := &dperf.DrivePerf{
-			Serial:    serial,
-			BlockSize: bs,
-			FileSize:  fs,
-			Verbose:   verbose,
+			Serial:     serial,
+			BlockSize:  bs,
+			FileSize:   fs,
+			Verbose:    verbose,
+			IOPerDrive: ioPerDrive,
 		}
 		paths := make([]string, 0, len(args))
 		for _, arg := range args {
@@ -175,6 +181,8 @@ func init() {
 		"filesize", "f", fileSize, "amount of data to read/write per drive")
 	dperfCmd.PersistentFlags().IntVarP(&cpuNode,
 		"cpunode", "c", -1, "execute on a specific CPU node, defaults to all CPU nodes")
+	dperfCmd.PersistentFlags().IntVarP(&ioPerDrive,
+		"ioperdrive", "i", ioPerDrive, "number of concurrent I/O per drive, default is 4")
 
 	dperfCmd.PersistentFlags().MarkHidden("alsologtostderr")
 	dperfCmd.PersistentFlags().MarkHidden("add_dir_header")


### PR DESCRIPTION
"ioperdrive" is fixed as 4 in code, but when there are multiple disks such as 12 disks in a server, the concurrent read result is abnormal.  
- this PR make "--ioperdrive" configurable by user. 
- and change default value from 4 to 2.

Here is test result in Intel Xeon 8480+  with 12 pcs   KIOXIA Corporation NVMe SSD Controller Cx6

# ./dperf -f 10GiB -i 4  /mnt/d{1..12}  --verbose
┌──────────┬───────────┬───────────┬───┐
│ PATH     │ READ      │ WRITE     │   │
│ /mnt/d10 │ 1.6 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d5  │ 1.6 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d1  │ 1.6 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d6  │ 1.6 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d7  │ 1.6 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d9  │ 1.6 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d2  │ 1.6 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d11 │ 1.6 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d3  │ 1.6 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d4  │ 1.6 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d8  │ 1.6 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d12 │ 1.6 GiB/s │ 1.1 GiB/s │ ✓ │
└──────────┴───────────┴───────────┴───┘
┌───────────┬────────────┐
│ TotalREAD │ TotalWRITE │
│ 19 GiB/s  │ 14 GiB/s   │
└───────────┴────────────┘

# ./dperf -f 10GiB   /mnt/d{1..12}  --verbose
┌──────────┬───────────┬───────────┬───┐
│ PATH     │ READ      │ WRITE     │   │
│ /mnt/d5  │ 2.1 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d1  │ 2.0 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d2  │ 2.0 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d3  │ 2.0 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d6  │ 2.0 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d8  │ 2.0 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d10 │ 2.0 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d4  │ 2.0 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d11 │ 2.0 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d12 │ 2.0 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d9  │ 2.0 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d7  │ 2.0 GiB/s │ 1.1 GiB/s │ ✓ │
└──────────┴───────────┴───────────┴───┘
┌───────────┬────────────┐
│ TotalREAD │ TotalWRITE │
│ 24 GiB/s  │ 13 GiB/s   │
└───────────┴────────────┘
# ./dperf -f 10GiB  -i 1 /mnt/d{1..12}  --verbose
┌──────────┬───────────┬───────────┬───┐
│ PATH     │ READ      │ WRITE     │   │
│ /mnt/d10 │ 3.0 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d12 │ 2.9 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d4  │ 2.9 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d11 │ 2.8 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d7  │ 2.8 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d3  │ 2.8 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d1  │ 2.8 GiB/s │ 1.0 GiB/s │ ✓ │
│ /mnt/d2  │ 2.8 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d8  │ 2.8 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d6  │ 2.7 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d9  │ 2.7 GiB/s │ 1.1 GiB/s │ ✓ │
│ /mnt/d5  │ 2.7 GiB/s │ 1.1 GiB/s │ ✓ │
└──────────┴───────────┴───────────┴───┘
┌───────────┬────────────┐
│ TotalREAD │ TotalWRITE │
│ 34 GiB/s  │ 13 GiB/s   │
└───────────┴────────────┘

