### PR TITLE
fix whitespace issue causing make build to fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install: build ## builds dperf
 	@echo "Installation successful. To learn more, try \"dperf --help\"."
 
 build: 
-        @CGO_ENABLED=0 go build --ldflags "-s -w"
+	@CGO_ENABLED=0 go build --ldflags "-s -w"
 
 clean:
 	@echo "Cleaning up all the generated files"


### PR DESCRIPTION
I'm raising this PR to address a simple whitespace issue that was causing the `make build` to fail. Here is an example run - 
`$ make build`
`make: Nothing to be done for 'build'.`

@harshavardhana can you kindly approve.