### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/pkg/dperf/perf.go
+++ b/pkg/dperf/perf.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 
 	"github.com/google/uuid"
-	"github.com/ncw/directio"
 )
 
 // DrivePerf options
@@ -55,7 +54,7 @@ func (d *DrivePerf) runTests(ctx context.Context, path string, testUUID string) 
 	dataBuffers := make([][]byte, d.IOPerDrive)
 	for i := 0; i < d.IOPerDrive; i++ {
 		// Read Aligned block upto a multiple of BlockSize
-		dataBuffers[i] = directio.AlignedBlock(int(d.BlockSize))
+		dataBuffers[i] = alignedBlock(int(d.BlockSize))
 	}
 
 	testUUIDPath := filepath.Join(path, testUUID)

--- a/pkg/dperf/run_linux.go
+++ b/pkg/dperf/run_linux.go
@@ -126,6 +126,11 @@ func (d *DrivePerf) runReadTest(ctx context.Context, path string, data []byte) (
 	return uint64(throughputInSeconds), nil
 }
 
+// alignedBlock - pass through to directio implementation.
+func alignedBlock(blockSize int) []byte {
+	return directio.AlignedBlock(blockSize)
+}
+
 // fdatasync - fdatasync() is similar to fsync(), but does not flush modified metadata
 // unless that metadata is needed in order to allow a subsequent data retrieval
 // to  be  correctly  handled.   For example, changes to st_atime or st_mtime

--- a/pkg/dperf/run_other.go
+++ b/pkg/dperf/run_other.go
@@ -28,3 +28,7 @@ func (d *DrivePerf) runReadTest(ctx context.Context, path string, _ []byte) (uin
 func (d *DrivePerf) runWriteTest(ctx context.Context, path string, _ []byte) (uint64, error) {
 	return 0, ErrNotImplemented
 }
+
+func alignedBlock(blockSize int) []byte {
+	return make([]byte, 0)
+}


### PR DESCRIPTION
minio's build was broken on OpenBSD by 9e83fbada3408be668900db134f1cad153838639.

(as noticed in https://github.com/minio/minio/commit/22b7c8cd8a3b4ec3df2da6e74a449aac9323af0b)

Thanks!

